### PR TITLE
Update OpportunityEntity.php

### DIFF
--- a/src/API/Companies/CompanyEntity.php
+++ b/src/API/Companies/CompanyEntity.php
@@ -58,6 +58,7 @@ class CompanyEntity extends DataTransferObject
     public string $phone;
     public ?string $postalCode;
     public ?int $quoteEmailMessageID;
+    public ?int $purchaseOrderTemplateID;
     public ?int $quoteTemplateID;
     public ?string $sicCode;
     public ?string $state;

--- a/src/API/Opportunities/OpportunityEntity.php
+++ b/src/API/Opportunities/OpportunityEntity.php
@@ -56,7 +56,7 @@ class OpportunityEntity extends DataTransferObject
     public ?int $revenueSpread;
     public ?string $revenueSpreadUnit;
     public ?int $salesOrderID;
-    public ?int $salesProcessPercentComplete;
+    public ?float $salesProcessPercentComplete;
     public ?float $semiannualCost;
     public ?float $semiannualRevenue;
     public int $stage;


### PR DESCRIPTION
AT API defines salesProcessPercentComplete as a decimal.  Querying Opportunities throws an error:

Fatal error: Uncaught Spatie\DataTransferObject\DataTransferObjectError: Invalid type: expected `Anteris\Autotask\API\Opportunities\OpportunityEntity::salesProcessPercentComplete` to be of type `integer`, instead got value `100`, which is double.