### PR TITLE
Fix attachment entity duplicate properties

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,14 @@
 {
-    "name": "anteris-dev/autotask-client",
-    "description": "This package provides a PHP API client for the Autotask REST API. It is strongly typed and it is a wonderful experience to work with these classes in any intelligent IDE with autocompletion.",
+    "name": "msullivanJIT/autotask-client",
+    "description": "This package provides a PHP API client for the Autotask REST API. It is strongly typed and it is a wonderful experience to work with these classes in any intelligent IDE with autocompletion. This is a fork of Anteris-Dev/autotask-client that fixes issues with attachments",
     "authors": [
         {
             "name": "Aidan Casey",
             "email": "aidan.casey@anteris.com"
+        },
+        {
+            "name": "Max Sullivan",
+            "email": "msullivan@jitoutsource.com"
         }
     ],
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "msullivanjit/autotask-client",
+    "name": "anteris-dev/autotask-client",
     "description": "This package provides a PHP API client for the Autotask REST API. It is strongly typed and it is a wonderful experience to work with these classes in any intelligent IDE with autocompletion. This is a fork of Anteris-Dev/autotask-client that fixes issues with attachments",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "anteris-dev/autotask-client",
+    "name": "msullianjit/autotask-client",
     "description": "This package provides a PHP API client for the Autotask REST API. It is strongly typed and it is a wonderful experience to work with these classes in any intelligent IDE with autocompletion. This is a fork of Anteris-Dev/autotask-client that fixes issues with attachments",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "msullivanJIT/autotask-client",
+    "name": "msullivanjit/autotask-client",
     "description": "This package provides a PHP API client for the Autotask REST API. It is strongly typed and it is a wonderful experience to work with these classes in any intelligent IDE with autocompletion. This is a fork of Anteris-Dev/autotask-client that fixes issues with attachments",
     "authors": [
         {

--- a/src/API/ArticleAttachments/ArticleAttachmentEntity.php
+++ b/src/API/ArticleAttachments/ArticleAttachmentEntity.php
@@ -18,7 +18,6 @@ class ArticleAttachmentEntity extends DataTransferObject
     public string $attachmentType;
     public ?string $contentType;
     public ?int $creatorType;
-    public ?byte[] $data;
     public $fileSize;
     public string $fullPath;
     public $id;

--- a/src/API/ArticleAttachments/ArticleAttachmentEntity.php
+++ b/src/API/ArticleAttachments/ArticleAttachmentEntity.php
@@ -27,7 +27,6 @@ class ArticleAttachmentEntity extends DataTransferObject
     public $parentID;
     public int $publish;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/CompanyAttachments/CompanyAttachmentEntity.php
+++ b/src/API/CompanyAttachments/CompanyAttachmentEntity.php
@@ -19,7 +19,6 @@ class CompanyAttachmentEntity extends DataTransferObject
     public ?int $companyNoteID;
     public ?string $contentType;
     public ?int $creatorType;
-    public ?byte[] $data;
     public $fileSize;
     public string $fullPath;
     public $id;

--- a/src/API/CompanyAttachments/CompanyAttachmentEntity.php
+++ b/src/API/CompanyAttachments/CompanyAttachmentEntity.php
@@ -30,7 +30,6 @@ class CompanyAttachmentEntity extends DataTransferObject
     public int $publish;
     public ?int $salesOrderID;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/CompanyNoteAttachments/CompanyNoteAttachmentEntity.php
+++ b/src/API/CompanyNoteAttachments/CompanyNoteAttachmentEntity.php
@@ -19,7 +19,6 @@ class CompanyNoteAttachmentEntity extends DataTransferObject
     public ?int $companyNoteID;
     public ?string $contentType;
     public ?int $creatorType;
-    public ?byte[] $data;
     public $fileSize;
     public string $fullPath;
     public $id;

--- a/src/API/CompanyNoteAttachments/CompanyNoteAttachmentEntity.php
+++ b/src/API/CompanyNoteAttachments/CompanyNoteAttachmentEntity.php
@@ -29,7 +29,6 @@ class CompanyNoteAttachmentEntity extends DataTransferObject
     public int $publish;
     public ?int $salesOrderID;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/ConfigurationItemAttachments/ConfigurationItemAttachmentEntity.php
+++ b/src/API/ConfigurationItemAttachments/ConfigurationItemAttachmentEntity.php
@@ -29,7 +29,6 @@ class ConfigurationItemAttachmentEntity extends DataTransferObject
     public $parentID;
     public int $publish;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/ConfigurationItemAttachments/ConfigurationItemAttachmentEntity.php
+++ b/src/API/ConfigurationItemAttachments/ConfigurationItemAttachmentEntity.php
@@ -19,7 +19,6 @@ class ConfigurationItemAttachmentEntity extends DataTransferObject
     public ?int $configurationItemNoteID;
     public ?string $contentType;
     public ?int $creatorType;
-    public ?byte[] $data;
     public $fileSize;
     public string $fullPath;
     public $id;

--- a/src/API/ConfigurationItemNoteAttachments/ConfigurationItemNoteAttachmentEntity.php
+++ b/src/API/ConfigurationItemNoteAttachments/ConfigurationItemNoteAttachmentEntity.php
@@ -19,7 +19,6 @@ class ConfigurationItemNoteAttachmentEntity extends DataTransferObject
     public ?int $configurationItemNoteID;
     public ?string $contentType;
     public ?int $creatorType;
-    public ?byte[] $data;
     public $fileSize;
     public string $fullPath;
     public $id;

--- a/src/API/ConfigurationItemNoteAttachments/ConfigurationItemNoteAttachmentEntity.php
+++ b/src/API/ConfigurationItemNoteAttachments/ConfigurationItemNoteAttachmentEntity.php
@@ -28,7 +28,6 @@ class ConfigurationItemNoteAttachmentEntity extends DataTransferObject
     public $parentID;
     public int $publish;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/ContractNoteAttachments/ContractNoteAttachmentEntity.php
+++ b/src/API/ContractNoteAttachments/ContractNoteAttachmentEntity.php
@@ -19,7 +19,6 @@ class ContractNoteAttachmentEntity extends DataTransferObject
     public ?int $contractID;
     public ?int $contractNoteID;
     public ?int $creatorType;
-    public ?byte[] $data;
     public $fileSize;
     public string $fullPath;
     public $id;

--- a/src/API/ContractNoteAttachments/ContractNoteAttachmentEntity.php
+++ b/src/API/ContractNoteAttachments/ContractNoteAttachmentEntity.php
@@ -28,7 +28,6 @@ class ContractNoteAttachmentEntity extends DataTransferObject
     public $parentID;
     public int $publish;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/DocumentAttachments/DocumentAttachmentEntity.php
+++ b/src/API/DocumentAttachments/DocumentAttachmentEntity.php
@@ -17,7 +17,6 @@ class DocumentAttachmentEntity extends DataTransferObject
     public string $attachmentType;
     public ?string $contentType;
     public ?int $creatorType;
-    public ?byte[] $data;
     public ?int $documentID;
     public $fileSize;
     public string $fullPath;

--- a/src/API/DocumentAttachments/DocumentAttachmentEntity.php
+++ b/src/API/DocumentAttachments/DocumentAttachmentEntity.php
@@ -27,7 +27,6 @@ class DocumentAttachmentEntity extends DataTransferObject
     public $parentID;
     public int $publish;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/ExpenseItemAttachments/ExpenseItemAttachmentEntity.php
+++ b/src/API/ExpenseItemAttachments/ExpenseItemAttachmentEntity.php
@@ -17,7 +17,6 @@ class ExpenseItemAttachmentEntity extends DataTransferObject
     public string $attachmentType;
     public ?string $contentType;
     public ?int $creatorType;
-    public ?byte[] $data;
     public ?int $expenseItemID;
     public ?int $expenseReportID;
     public $fileSize;

--- a/src/API/ExpenseItemAttachments/ExpenseItemAttachmentEntity.php
+++ b/src/API/ExpenseItemAttachments/ExpenseItemAttachmentEntity.php
@@ -28,7 +28,6 @@ class ExpenseItemAttachmentEntity extends DataTransferObject
     public $parentID;
     public int $publish;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/ExpenseReportAttachments/ExpenseReportAttachmentEntity.php
+++ b/src/API/ExpenseReportAttachments/ExpenseReportAttachmentEntity.php
@@ -28,7 +28,6 @@ class ExpenseReportAttachmentEntity extends DataTransferObject
     public $parentID;
     public int $publish;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/ExpenseReportAttachments/ExpenseReportAttachmentEntity.php
+++ b/src/API/ExpenseReportAttachments/ExpenseReportAttachmentEntity.php
@@ -17,7 +17,6 @@ class ExpenseReportAttachmentEntity extends DataTransferObject
     public string $attachmentType;
     public ?string $contentType;
     public ?int $creatorType;
-    public ?byte[] $data;
     public ?int $expenseItemID;
     public ?int $expenseReportID;
     public $fileSize;

--- a/src/API/OpportunityAttachments/OpportunityAttachmentEntity.php
+++ b/src/API/OpportunityAttachments/OpportunityAttachmentEntity.php
@@ -26,7 +26,6 @@ class OpportunityAttachmentEntity extends DataTransferObject
     public $parentID;
     public int $publish;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/OpportunityAttachments/OpportunityAttachmentEntity.php
+++ b/src/API/OpportunityAttachments/OpportunityAttachmentEntity.php
@@ -17,7 +17,6 @@ class OpportunityAttachmentEntity extends DataTransferObject
     public string $attachmentType;
     public ?string $contentType;
     public ?int $creatorType;
-    public ?byte[] $data;
     public $fileSize;
     public string $fullPath;
     public $id;

--- a/src/API/ProjectAttachments/ProjectAttachmentEntity.php
+++ b/src/API/ProjectAttachments/ProjectAttachmentEntity.php
@@ -17,7 +17,6 @@ class ProjectAttachmentEntity extends DataTransferObject
     public string $attachmentType;
     public ?string $contentType;
     public ?int $creatorType;
-    public ?byte[] $data;
     public $fileSize;
     public string $fullPath;
     public $id;

--- a/src/API/ProjectAttachments/ProjectAttachmentEntity.php
+++ b/src/API/ProjectAttachments/ProjectAttachmentEntity.php
@@ -28,7 +28,6 @@ class ProjectAttachmentEntity extends DataTransferObject
     public ?int $projectNoteID;
     public int $publish;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/ProjectNoteAttachments/ProjectNoteAttachmentEntity.php
+++ b/src/API/ProjectNoteAttachments/ProjectNoteAttachmentEntity.php
@@ -29,7 +29,6 @@ class ProjectNoteAttachmentEntity extends DataTransferObject
     public ?int $projectNoteID;
     public int $publish;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/ProjectNoteAttachments/ProjectNoteAttachmentEntity.php
+++ b/src/API/ProjectNoteAttachments/ProjectNoteAttachmentEntity.php
@@ -17,7 +17,6 @@ class ProjectNoteAttachmentEntity extends DataTransferObject
     public string $attachmentType;
     public ?string $contentType;
     public ?int $creatorType;
-    public ?byte[] $data;
     public $fileSize;
     public string $fullPath;
     public $id;

--- a/src/API/ResourceAttachments/ResourceAttachmentEntity.php
+++ b/src/API/ResourceAttachments/ResourceAttachmentEntity.php
@@ -17,7 +17,6 @@ class ResourceAttachmentEntity extends DataTransferObject
     public string $attachmentType;
     public ?string $contentType;
     public ?int $creatorType;
-    public ?byte[] $data;
     public $fileSize;
     public string $fullPath;
     public $id;

--- a/src/API/ResourceAttachments/ResourceAttachmentEntity.php
+++ b/src/API/ResourceAttachments/ResourceAttachmentEntity.php
@@ -27,7 +27,6 @@ class ResourceAttachmentEntity extends DataTransferObject
     public int $publish;
     public ?int $resourceID;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/SalesOrderAttachments/SalesOrderAttachmentEntity.php
+++ b/src/API/SalesOrderAttachments/SalesOrderAttachmentEntity.php
@@ -27,7 +27,6 @@ class SalesOrderAttachmentEntity extends DataTransferObject
     public int $publish;
     public ?int $salesOrderID;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/SalesOrderAttachments/SalesOrderAttachmentEntity.php
+++ b/src/API/SalesOrderAttachments/SalesOrderAttachmentEntity.php
@@ -17,7 +17,6 @@ class SalesOrderAttachmentEntity extends DataTransferObject
     public string $attachmentType;
     public ?string $contentType;
     public ?int $creatorType;
-    public ?byte[] $data;
     public $fileSize;
     public string $fullPath;
     public $id;

--- a/src/API/TaskAttachments/TaskAttachmentEntity.php
+++ b/src/API/TaskAttachments/TaskAttachmentEntity.php
@@ -17,7 +17,6 @@ class TaskAttachmentEntity extends DataTransferObject
     public string $attachmentType;
     public ?string $contentType;
     public ?int $creatorType;
-    public ?byte[] $data;
     public $fileSize;
     public string $fullPath;
     public $id;

--- a/src/API/TaskAttachments/TaskAttachmentEntity.php
+++ b/src/API/TaskAttachments/TaskAttachmentEntity.php
@@ -30,7 +30,6 @@ class TaskAttachmentEntity extends DataTransferObject
     public ?int $taskNoteID;
     public ?int $timeEntryID;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/TaskNoteAttachments/TaskNoteAttachmentEntity.php
+++ b/src/API/TaskNoteAttachments/TaskNoteAttachmentEntity.php
@@ -28,7 +28,6 @@ class TaskNoteAttachmentEntity extends DataTransferObject
     public ?int $taskID;
     public ?int $taskNoteID;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/TaskNoteAttachments/TaskNoteAttachmentEntity.php
+++ b/src/API/TaskNoteAttachments/TaskNoteAttachmentEntity.php
@@ -17,7 +17,6 @@ class TaskNoteAttachmentEntity extends DataTransferObject
     public string $attachmentType;
     public ?string $contentType;
     public ?int $creatorType;
-    public ?byte[] $data;
     public $fileSize;
     public string $fullPath;
     public $id;

--- a/src/API/TicketAttachments/TicketAttachmentEntity.php
+++ b/src/API/TicketAttachments/TicketAttachmentEntity.php
@@ -30,7 +30,6 @@ class TicketAttachmentEntity extends DataTransferObject
     public ?int $ticketNoteID;
     public ?int $timeEntryID;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/TicketAttachments/TicketAttachmentEntity.php
+++ b/src/API/TicketAttachments/TicketAttachmentEntity.php
@@ -17,7 +17,6 @@ class TicketAttachmentEntity extends DataTransferObject
     public string $attachmentType;
     public ?string $contentType;
     public ?int $creatorType;
-    public ?byte[] $data;
     public $fileSize;
     public string $fullPath;
     public $id;

--- a/src/API/TicketAttachments/TicketAttachmentService.php
+++ b/src/API/TicketAttachments/TicketAttachmentService.php
@@ -61,9 +61,9 @@ class TicketAttachmentService
      *
      * @author Aidan Casey <aidan.casey@anteris.com>
      */
-    public function findById(int $id): TicketAttachmentEntity
+    public function findById(int $id): TicketAttachmentCollection
     {
-        return TicketAttachmentEntity::fromResponse(
+        return TicketAttachmentCollection::fromResponse(
             $this->client->get("TicketAttachments/$id")
         );
     }

--- a/src/API/TicketNoteAttachments/TicketNoteAttachmentEntity.php
+++ b/src/API/TicketNoteAttachments/TicketNoteAttachmentEntity.php
@@ -17,7 +17,6 @@ class TicketNoteAttachmentEntity extends DataTransferObject
     public string $attachmentType;
     public ?string $contentType;
     public ?int $creatorType;
-    public ?byte[] $data;
     public $fileSize;
     public string $fullPath;
     public $id;

--- a/src/API/TicketNoteAttachments/TicketNoteAttachmentEntity.php
+++ b/src/API/TicketNoteAttachments/TicketNoteAttachmentEntity.php
@@ -28,7 +28,6 @@ class TicketNoteAttachmentEntity extends DataTransferObject
     public ?int $ticketID;
     public ?int $ticketNoteID;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/TimeEntryAttachments/TimeEntryAttachmentEntity.php
+++ b/src/API/TimeEntryAttachments/TimeEntryAttachmentEntity.php
@@ -17,7 +17,6 @@ class TimeEntryAttachmentEntity extends DataTransferObject
     public string $attachmentType;
     public ?string $contentType;
     public ?int $creatorType;
-    public ?byte[] $data;
     public $fileSize;
     public string $fullPath;
     public $id;

--- a/src/API/TimeEntryAttachments/TimeEntryAttachmentEntity.php
+++ b/src/API/TimeEntryAttachments/TimeEntryAttachmentEntity.php
@@ -29,7 +29,6 @@ class TimeEntryAttachmentEntity extends DataTransferObject
     public ?int $ticketID;
     public ?int $timeEntryID;
     public string $title;
-    public $id;
     public ?string $data;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/TimeEntryAttachments/TimeEntryAttachmentService.php
+++ b/src/API/TimeEntryAttachments/TimeEntryAttachmentService.php
@@ -59,9 +59,9 @@ class TimeEntryAttachmentService
      *
      * @author Aidan Casey <aidan.casey@anteris.com>
      */
-    public function findById(int $id): TicketAttachmentCollection
+    public function findById(int $id): TimeEntryAttachmentEntity
     {
-        return TicketAttachmentCollection::fromResponse(
+        return TimeEntryAttachmentEntity::fromResponse(
             $this->client->get("TimeEntryAttachments/$id")
         );
     }

--- a/src/API/TimeEntryAttachments/TimeEntryAttachmentService.php
+++ b/src/API/TimeEntryAttachments/TimeEntryAttachmentService.php
@@ -59,9 +59,9 @@ class TimeEntryAttachmentService
      *
      * @author Aidan Casey <aidan.casey@anteris.com>
      */
-    public function findById(int $id): TimeEntryAttachmentEntity
+    public function findById(int $id): TicketAttachmentCollection
     {
-        return TimeEntryAttachmentEntity::fromResponse(
+        return TicketAttachmentCollection::fromResponse(
             $this->client->get("TimeEntryAttachments/$id")
         );
     }


### PR DESCRIPTION
I ran into issue #59 myself trying to work with ticket attachments and I created this PR to resolve, however after I created it I  realized this issue is probably caused by the generator and an issue should be created there? 

All of the attachment related entities have duplicate $id and $data properties.  I removed the duplicate $id properties and the duplicate ?byte[] $data property since I don't believe php has a byte type.  The remaining string type $data property remains. 