### PR TITLE
Add $contractBlockID to BillingItemEntity.php

### DIFF
--- a/src/API/BillingItems/BillingItemEntity.php
+++ b/src/API/BillingItems/BillingItemEntity.php
@@ -18,6 +18,7 @@ class BillingItemEntity extends DataTransferObject
     public $configurationItemID;
     public $contractChargeID;
     public ?int $contractID;
+    public ?int $contractBlockID;
     public ?int $contractServiceAdjustmentID;
     public ?int $contractServiceBundleAdjustmentID;
     public ?int $contractServiceBundleID;


### PR DESCRIPTION
API Release 2022.2 added this field, without it, we cannot instantiate a new BillingItem to create charges.

API Release notes: [https://psa.datto.com/releasenotes/Content/BY_RELEASE_NUMBER/2022.2ReleaseNotes.htm](url)