### PR TITLE
fixed property spelling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "anteris-dev/autotask-client",
+    "name": "tux2442/autotask-client",
     "description": "This package provides a PHP API client for the Autotask REST API. It is strongly typed and it is a wonderful experience to work with these classes in any intelligent IDE with autocompletion.",
     "authors": [
         {

--- a/src/API/CompanyCategories/CompanyCategoryEntity.php
+++ b/src/API/CompanyCategories/CompanyCategoryEntity.php
@@ -10,7 +10,7 @@ use Spatie\DataTransferObject\DataTransferObject;
  */
 class CompanyCategoryEntity extends DataTransferObject
 {
-    public int $displayColorRgb;
+    public int $displayColorRGB;
     public $id;
     public bool $isActive;
     public ?bool $isApiOnly;

--- a/src/API/CompanyWebhookExcludedResources/CompanyWebhookExcludedResourceService.php
+++ b/src/API/CompanyWebhookExcludedResources/CompanyWebhookExcludedResourceService.php
@@ -37,21 +37,21 @@ class CompanyWebhookExcludedResourceService
      */
     public function create(CompanyWebhookExcludedResourceEntity $resource): Response
     {
-        $resourceID = $resource->resourceID;
-        return $this->client->post("CompanyWebhooks/$resourceID/ExcludedResources", $resource->toArray());
+        $webhookID = $resource->webhookID;
+        return $this->client->post("CompanyWebhooks/$webhookID/ExcludedResources", $resource->toArray());
     }
 
     /**
      * Deletes an entity by its ID.
      *
-     * @param  int  $resourceID  ID of the CompanyWebhookExcludedResource parent resource.
+     * @param  int  $webhookID  ID of the CompanyWebhookExcludedResource parent resource.
      * @param  int  $id  ID of the CompanyWebhookExcludedResource to be deleted.
      *
      * @author Aidan Casey <aidan.casey@anteris.com>
      */
-    public function deleteById(int $resourceID,int $id): void
+    public function deleteById(int $webhookID,int $id): void
     {
-        $this->client->delete("CompanyWebhooks/$resourceID/ExcludedResources/$id");
+        $this->client->delete("CompanyWebhooks/$webhookID/ExcludedResources/$id");
     }
 
     /**


### PR DESCRIPTION
Fixes a spelling mistake, which prevents the entity from instantiating. 