### PR TITLE
add payrollIdentifier as nullable string property https://www.autotas…

### DIFF
--- a/src/API/Resources/ResourceEntity.php
+++ b/src/API/Resources/ResourceEntity.php
@@ -38,6 +38,7 @@ class ResourceEntity extends DataTransferObject
     public ?string $officeExtension;
     public ?string $officePhone;
     public int $payrollType;
+    public ?string $payrollIdentifier;
     public string $resourceType;
     public ?int $suffix;
     public ?float $surveyResourceRating;


### PR DESCRIPTION
payrollIdentifier missing from resource entity 
https://www.autotask.net/help/developerhelp/Content/APIs/REST/Entities/ResourcesEntity.htm

<html>
<body>
<!--StartFragment-->

payrollIdentifier | Payroll Identifier on the HRl tab.An ID that links the resource to an external payroll application. | string (32)
-- | -- | --


<!--EndFragment-->
</body>
</html>