### PR TITLE
From response unable to handle items in response

### DIFF
--- a/src/API/Resources/ResourceEntity.php
+++ b/src/API/Resources/ResourceEntity.php
@@ -38,6 +38,7 @@ class ResourceEntity extends DataTransferObject
     public ?string $officeExtension;
     public ?string $officePhone;
     public int $payrollType;
+    public ?string $payrollIdentifier;
     public string $resourceType;
     public ?int $suffix;
     public ?float $surveyResourceRating;

--- a/src/API/TicketAttachments/TicketAttachmentEntity.php
+++ b/src/API/TicketAttachments/TicketAttachmentEntity.php
@@ -59,6 +59,11 @@ class TicketAttachmentEntity extends DataTransferObject
     {
         $responseArray = json_decode($response->getBody(), true);
 
+        //findByID method returns $responseArray["items"], but there should always only be 1 item returned from the API by ID. 
+        if(isset($responseArray["items"]) && is_array($responseArray["items"]) && count($responseArray["items"]) == 1){
+            return new self($responseArray["items"][0]);
+        }
+
         if (isset($responseArray['item']) === false) {
             throw new \Exception('Missing item key in response.');
         }


### PR DESCRIPTION
I'm not sure if there is a better way to handle this, but when using TicketAttachmentService->findById(), the response from the API returns an array of [items] and TicketAttachmentEntity->fromResponse() has no way to handle a response with an array for $responseArray["items"] and only accounts for a $responseArray["item"].  The update verifies there is only 1 response in the ["items"] since there should only be 1 response when searching by ID and then returns the individual item as ["items"][0].