### PR TITLE
Passing null parameter strolower() deprecated in php 8.1

### DIFF
--- a/src/API/ActionTypes/ActionTypeQueryBuilder.php
+++ b/src/API/ActionTypes/ActionTypeQueryBuilder.php
@@ -151,7 +151,7 @@ class ActionTypeQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ActionTypeQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/AdditionalInvoiceFieldValues/AdditionalInvoiceFieldValueQueryBuilder.php
+++ b/src/API/AdditionalInvoiceFieldValues/AdditionalInvoiceFieldValueQueryBuilder.php
@@ -151,7 +151,7 @@ class AdditionalInvoiceFieldValueQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class AdditionalInvoiceFieldValueQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Appointments/AppointmentQueryBuilder.php
+++ b/src/API/Appointments/AppointmentQueryBuilder.php
@@ -151,7 +151,7 @@ class AppointmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class AppointmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ArticleAttachments/ArticleAttachmentQueryBuilder.php
+++ b/src/API/ArticleAttachments/ArticleAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class ArticleAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ArticleAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ArticleConfigurationItemCategoryAssociations/ArticleConfigurationItemCategoryAssociationQueryBuilder.php
+++ b/src/API/ArticleConfigurationItemCategoryAssociations/ArticleConfigurationItemCategoryAssociationQueryBuilder.php
@@ -151,7 +151,7 @@ class ArticleConfigurationItemCategoryAssociationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ArticleConfigurationItemCategoryAssociationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ArticleNotes/ArticleNoteQueryBuilder.php
+++ b/src/API/ArticleNotes/ArticleNoteQueryBuilder.php
@@ -151,7 +151,7 @@ class ArticleNoteQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ArticleNoteQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ArticlePlainTextContent/ArticlePlainTextContentQueryBuilder.php
+++ b/src/API/ArticlePlainTextContent/ArticlePlainTextContentQueryBuilder.php
@@ -151,7 +151,7 @@ class ArticlePlainTextContentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ArticlePlainTextContentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ArticleTagAssociations/ArticleTagAssociationQueryBuilder.php
+++ b/src/API/ArticleTagAssociations/ArticleTagAssociationQueryBuilder.php
@@ -151,7 +151,7 @@ class ArticleTagAssociationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ArticleTagAssociationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ArticleTicketAssociations/ArticleTicketAssociationQueryBuilder.php
+++ b/src/API/ArticleTicketAssociations/ArticleTicketAssociationQueryBuilder.php
@@ -151,7 +151,7 @@ class ArticleTicketAssociationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ArticleTicketAssociationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ArticleToArticleAssociations/ArticleToArticleAssociationQueryBuilder.php
+++ b/src/API/ArticleToArticleAssociations/ArticleToArticleAssociationQueryBuilder.php
@@ -151,7 +151,7 @@ class ArticleToArticleAssociationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ArticleToArticleAssociationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ArticleToDocumentAssociations/ArticleToDocumentAssociationQueryBuilder.php
+++ b/src/API/ArticleToDocumentAssociations/ArticleToDocumentAssociationQueryBuilder.php
@@ -151,7 +151,7 @@ class ArticleToDocumentAssociationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ArticleToDocumentAssociationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/AttachmentInfo/AttachmentInfoQueryBuilder.php
+++ b/src/API/AttachmentInfo/AttachmentInfoQueryBuilder.php
@@ -151,7 +151,7 @@ class AttachmentInfoQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class AttachmentInfoQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/AttachmentNestedAttachments/AttachmentNestedAttachmentQueryBuilder.php
+++ b/src/API/AttachmentNestedAttachments/AttachmentNestedAttachmentQueryBuilder.php
@@ -137,7 +137,7 @@ class AttachmentNestedAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -166,7 +166,7 @@ class AttachmentNestedAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/BillingCodes/BillingCodeQueryBuilder.php
+++ b/src/API/BillingCodes/BillingCodeQueryBuilder.php
@@ -151,7 +151,7 @@ class BillingCodeQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class BillingCodeQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/BillingItemApprovalLevels/BillingItemApprovalLevelQueryBuilder.php
+++ b/src/API/BillingItemApprovalLevels/BillingItemApprovalLevelQueryBuilder.php
@@ -151,7 +151,7 @@ class BillingItemApprovalLevelQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class BillingItemApprovalLevelQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/BillingItems/BillingItemQueryBuilder.php
+++ b/src/API/BillingItems/BillingItemQueryBuilder.php
@@ -151,7 +151,7 @@ class BillingItemQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class BillingItemQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ChangeOrderCharges/ChangeOrderChargeQueryBuilder.php
+++ b/src/API/ChangeOrderCharges/ChangeOrderChargeQueryBuilder.php
@@ -151,7 +151,7 @@ class ChangeOrderChargeQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ChangeOrderChargeQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ChangeRequestLinks/ChangeRequestLinkQueryBuilder.php
+++ b/src/API/ChangeRequestLinks/ChangeRequestLinkQueryBuilder.php
@@ -151,7 +151,7 @@ class ChangeRequestLinkQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ChangeRequestLinkQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ChecklistLibraries/ChecklistLibraryQueryBuilder.php
+++ b/src/API/ChecklistLibraries/ChecklistLibraryQueryBuilder.php
@@ -151,7 +151,7 @@ class ChecklistLibraryQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ChecklistLibraryQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ChecklistLibraryChecklistItems/ChecklistLibraryChecklistItemQueryBuilder.php
+++ b/src/API/ChecklistLibraryChecklistItems/ChecklistLibraryChecklistItemQueryBuilder.php
@@ -151,7 +151,7 @@ class ChecklistLibraryChecklistItemQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ChecklistLibraryChecklistItemQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ClassificationIcons/ClassificationIconQueryBuilder.php
+++ b/src/API/ClassificationIcons/ClassificationIconQueryBuilder.php
@@ -151,7 +151,7 @@ class ClassificationIconQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ClassificationIconQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ClientPortalUsers/ClientPortalUserQueryBuilder.php
+++ b/src/API/ClientPortalUsers/ClientPortalUserQueryBuilder.php
@@ -151,7 +151,7 @@ class ClientPortalUserQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ClientPortalUserQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ComanagedAssociations/ComanagedAssociationQueryBuilder.php
+++ b/src/API/ComanagedAssociations/ComanagedAssociationQueryBuilder.php
@@ -151,7 +151,7 @@ class ComanagedAssociationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ComanagedAssociationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Companies/CompanyQueryBuilder.php
+++ b/src/API/Companies/CompanyQueryBuilder.php
@@ -151,7 +151,7 @@ class CompanyQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class CompanyQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/CompanyAlerts/CompanyAlertQueryBuilder.php
+++ b/src/API/CompanyAlerts/CompanyAlertQueryBuilder.php
@@ -151,7 +151,7 @@ class CompanyAlertQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class CompanyAlertQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/CompanyAttachments/CompanyAttachmentQueryBuilder.php
+++ b/src/API/CompanyAttachments/CompanyAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class CompanyAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class CompanyAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/CompanyCategories/CompanyCategoryQueryBuilder.php
+++ b/src/API/CompanyCategories/CompanyCategoryQueryBuilder.php
@@ -151,7 +151,7 @@ class CompanyCategoryQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class CompanyCategoryQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/CompanyLocations/CompanyLocationQueryBuilder.php
+++ b/src/API/CompanyLocations/CompanyLocationQueryBuilder.php
@@ -151,7 +151,7 @@ class CompanyLocationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class CompanyLocationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/CompanyNoteAttachments/CompanyNoteAttachmentQueryBuilder.php
+++ b/src/API/CompanyNoteAttachments/CompanyNoteAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class CompanyNoteAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class CompanyNoteAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/CompanyNotes/CompanyNoteQueryBuilder.php
+++ b/src/API/CompanyNotes/CompanyNoteQueryBuilder.php
@@ -151,7 +151,7 @@ class CompanyNoteQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class CompanyNoteQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/CompanySiteConfigurations/CompanySiteConfigurationQueryBuilder.php
+++ b/src/API/CompanySiteConfigurations/CompanySiteConfigurationQueryBuilder.php
@@ -151,7 +151,7 @@ class CompanySiteConfigurationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class CompanySiteConfigurationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/CompanyTeams/CompanyTeamQueryBuilder.php
+++ b/src/API/CompanyTeams/CompanyTeamQueryBuilder.php
@@ -151,7 +151,7 @@ class CompanyTeamQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class CompanyTeamQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/CompanyToDos/CompanyToDoQueryBuilder.php
+++ b/src/API/CompanyToDos/CompanyToDoQueryBuilder.php
@@ -151,7 +151,7 @@ class CompanyToDoQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class CompanyToDoQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/CompanyWebhookExcludedResources/CompanyWebhookExcludedResourceQueryBuilder.php
+++ b/src/API/CompanyWebhookExcludedResources/CompanyWebhookExcludedResourceQueryBuilder.php
@@ -151,7 +151,7 @@ class CompanyWebhookExcludedResourceQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class CompanyWebhookExcludedResourceQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/CompanyWebhookFields/CompanyWebhookFieldQueryBuilder.php
+++ b/src/API/CompanyWebhookFields/CompanyWebhookFieldQueryBuilder.php
@@ -151,7 +151,7 @@ class CompanyWebhookFieldQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class CompanyWebhookFieldQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/CompanyWebhookUdfFields/CompanyWebhookUdfFieldQueryBuilder.php
+++ b/src/API/CompanyWebhookUdfFields/CompanyWebhookUdfFieldQueryBuilder.php
@@ -151,7 +151,7 @@ class CompanyWebhookUdfFieldQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class CompanyWebhookUdfFieldQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/CompanyWebhooks/CompanyWebhookQueryBuilder.php
+++ b/src/API/CompanyWebhooks/CompanyWebhookQueryBuilder.php
@@ -151,7 +151,7 @@ class CompanyWebhookQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class CompanyWebhookQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ConfigurationItemAttachments/ConfigurationItemAttachmentQueryBuilder.php
+++ b/src/API/ConfigurationItemAttachments/ConfigurationItemAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class ConfigurationItemAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ConfigurationItemAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ConfigurationItemBillingProductAssociations/ConfigurationItemBillingProductAssociationQueryBuilder.php
+++ b/src/API/ConfigurationItemBillingProductAssociations/ConfigurationItemBillingProductAssociationQueryBuilder.php
@@ -151,7 +151,7 @@ class ConfigurationItemBillingProductAssociationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ConfigurationItemBillingProductAssociationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ConfigurationItemCategories/ConfigurationItemCategoryQueryBuilder.php
+++ b/src/API/ConfigurationItemCategories/ConfigurationItemCategoryQueryBuilder.php
@@ -151,7 +151,7 @@ class ConfigurationItemCategoryQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ConfigurationItemCategoryQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ConfigurationItemCategoryUdfAssociations/ConfigurationItemCategoryUdfAssociationQueryBuilder.php
+++ b/src/API/ConfigurationItemCategoryUdfAssociations/ConfigurationItemCategoryUdfAssociationQueryBuilder.php
@@ -151,7 +151,7 @@ class ConfigurationItemCategoryUdfAssociationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ConfigurationItemCategoryUdfAssociationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ConfigurationItemDnsRecords/ConfigurationItemDnsRecordQueryBuilder.php
+++ b/src/API/ConfigurationItemDnsRecords/ConfigurationItemDnsRecordQueryBuilder.php
@@ -151,7 +151,7 @@ class ConfigurationItemDnsRecordQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ConfigurationItemDnsRecordQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ConfigurationItemNoteAttachments/ConfigurationItemNoteAttachmentQueryBuilder.php
+++ b/src/API/ConfigurationItemNoteAttachments/ConfigurationItemNoteAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class ConfigurationItemNoteAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ConfigurationItemNoteAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ConfigurationItemNotes/ConfigurationItemNoteQueryBuilder.php
+++ b/src/API/ConfigurationItemNotes/ConfigurationItemNoteQueryBuilder.php
@@ -151,7 +151,7 @@ class ConfigurationItemNoteQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ConfigurationItemNoteQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ConfigurationItemRelatedItems/ConfigurationItemRelatedItemQueryBuilder.php
+++ b/src/API/ConfigurationItemRelatedItems/ConfigurationItemRelatedItemQueryBuilder.php
@@ -151,7 +151,7 @@ class ConfigurationItemRelatedItemQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ConfigurationItemRelatedItemQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ConfigurationItemSslSubjectAlternativeNames/ConfigurationItemSslSubjectAlternativeNameQueryBuilder.php
+++ b/src/API/ConfigurationItemSslSubjectAlternativeNames/ConfigurationItemSslSubjectAlternativeNameQueryBuilder.php
@@ -151,7 +151,7 @@ class ConfigurationItemSslSubjectAlternativeNameQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ConfigurationItemSslSubjectAlternativeNameQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ConfigurationItemTypes/ConfigurationItemTypeQueryBuilder.php
+++ b/src/API/ConfigurationItemTypes/ConfigurationItemTypeQueryBuilder.php
@@ -151,7 +151,7 @@ class ConfigurationItemTypeQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ConfigurationItemTypeQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ConfigurationItemWebhookExcludedResources/ConfigurationItemWebhookExcludedResourceQueryBuilder.php
+++ b/src/API/ConfigurationItemWebhookExcludedResources/ConfigurationItemWebhookExcludedResourceQueryBuilder.php
@@ -151,7 +151,7 @@ class ConfigurationItemWebhookExcludedResourceQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ConfigurationItemWebhookExcludedResourceQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ConfigurationItemWebhookFields/ConfigurationItemWebhookFieldQueryBuilder.php
+++ b/src/API/ConfigurationItemWebhookFields/ConfigurationItemWebhookFieldQueryBuilder.php
@@ -151,7 +151,7 @@ class ConfigurationItemWebhookFieldQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ConfigurationItemWebhookFieldQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ConfigurationItemWebhookUdfFields/ConfigurationItemWebhookUdfFieldQueryBuilder.php
+++ b/src/API/ConfigurationItemWebhookUdfFields/ConfigurationItemWebhookUdfFieldQueryBuilder.php
@@ -151,7 +151,7 @@ class ConfigurationItemWebhookUdfFieldQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ConfigurationItemWebhookUdfFieldQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ConfigurationItemWebhooks/ConfigurationItemWebhookQueryBuilder.php
+++ b/src/API/ConfigurationItemWebhooks/ConfigurationItemWebhookQueryBuilder.php
@@ -151,7 +151,7 @@ class ConfigurationItemWebhookQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ConfigurationItemWebhookQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ConfigurationItems/ConfigurationItemQueryBuilder.php
+++ b/src/API/ConfigurationItems/ConfigurationItemQueryBuilder.php
@@ -151,7 +151,7 @@ class ConfigurationItemQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ConfigurationItemQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContactBillingProductAssociations/ContactBillingProductAssociationQueryBuilder.php
+++ b/src/API/ContactBillingProductAssociations/ContactBillingProductAssociationQueryBuilder.php
@@ -151,7 +151,7 @@ class ContactBillingProductAssociationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContactBillingProductAssociationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContactGroupContacts/ContactGroupContactQueryBuilder.php
+++ b/src/API/ContactGroupContacts/ContactGroupContactQueryBuilder.php
@@ -151,7 +151,7 @@ class ContactGroupContactQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContactGroupContactQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContactGroups/ContactGroupQueryBuilder.php
+++ b/src/API/ContactGroups/ContactGroupQueryBuilder.php
@@ -151,7 +151,7 @@ class ContactGroupQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContactGroupQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContactWebhookExcludedResources/ContactWebhookExcludedResourceQueryBuilder.php
+++ b/src/API/ContactWebhookExcludedResources/ContactWebhookExcludedResourceQueryBuilder.php
@@ -151,7 +151,7 @@ class ContactWebhookExcludedResourceQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContactWebhookExcludedResourceQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContactWebhookFields/ContactWebhookFieldQueryBuilder.php
+++ b/src/API/ContactWebhookFields/ContactWebhookFieldQueryBuilder.php
@@ -151,7 +151,7 @@ class ContactWebhookFieldQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContactWebhookFieldQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContactWebhookUdfFields/ContactWebhookUdfFieldQueryBuilder.php
+++ b/src/API/ContactWebhookUdfFields/ContactWebhookUdfFieldQueryBuilder.php
@@ -151,7 +151,7 @@ class ContactWebhookUdfFieldQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContactWebhookUdfFieldQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContactWebhooks/ContactWebhookQueryBuilder.php
+++ b/src/API/ContactWebhooks/ContactWebhookQueryBuilder.php
@@ -151,7 +151,7 @@ class ContactWebhookQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContactWebhookQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Contacts/ContactQueryBuilder.php
+++ b/src/API/Contacts/ContactQueryBuilder.php
@@ -151,7 +151,7 @@ class ContactQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContactQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractBillingRules/ContractBillingRuleQueryBuilder.php
+++ b/src/API/ContractBillingRules/ContractBillingRuleQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractBillingRuleQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractBillingRuleQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractBlockHourFactors/ContractBlockHourFactorQueryBuilder.php
+++ b/src/API/ContractBlockHourFactors/ContractBlockHourFactorQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractBlockHourFactorQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractBlockHourFactorQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractBlocks/ContractBlockQueryBuilder.php
+++ b/src/API/ContractBlocks/ContractBlockQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractBlockQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractBlockQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractCharges/ContractChargeQueryBuilder.php
+++ b/src/API/ContractCharges/ContractChargeQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractChargeQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractChargeQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractExclusionBillingCodes/ContractExclusionBillingCodeQueryBuilder.php
+++ b/src/API/ContractExclusionBillingCodes/ContractExclusionBillingCodeQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractExclusionBillingCodeQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractExclusionBillingCodeQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractExclusionRoles/ContractExclusionRoleQueryBuilder.php
+++ b/src/API/ContractExclusionRoles/ContractExclusionRoleQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractExclusionRoleQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractExclusionRoleQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractExclusionSetExcludedRoles/ContractExclusionSetExcludedRoleQueryBuilder.php
+++ b/src/API/ContractExclusionSetExcludedRoles/ContractExclusionSetExcludedRoleQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractExclusionSetExcludedRoleQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractExclusionSetExcludedRoleQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractExclusionSetExcludedWorkTypes/ContractExclusionSetExcludedWorkTypeQueryBuilder.php
+++ b/src/API/ContractExclusionSetExcludedWorkTypes/ContractExclusionSetExcludedWorkTypeQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractExclusionSetExcludedWorkTypeQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractExclusionSetExcludedWorkTypeQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractExclusionSets/ContractExclusionSetQueryBuilder.php
+++ b/src/API/ContractExclusionSets/ContractExclusionSetQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractExclusionSetQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractExclusionSetQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractMilestones/ContractMilestoneQueryBuilder.php
+++ b/src/API/ContractMilestones/ContractMilestoneQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractMilestoneQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractMilestoneQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractNoteAttachments/ContractNoteAttachmentQueryBuilder.php
+++ b/src/API/ContractNoteAttachments/ContractNoteAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractNoteAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractNoteAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractNotes/ContractNoteQueryBuilder.php
+++ b/src/API/ContractNotes/ContractNoteQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractNoteQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractNoteQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractRates/ContractRateQueryBuilder.php
+++ b/src/API/ContractRates/ContractRateQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractRateQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractRateQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractRetainers/ContractRetainerQueryBuilder.php
+++ b/src/API/ContractRetainers/ContractRetainerQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractRetainerQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractRetainerQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractRoleCosts/ContractRoleCostQueryBuilder.php
+++ b/src/API/ContractRoleCosts/ContractRoleCostQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractRoleCostQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractRoleCostQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractServiceBundleUnits/ContractServiceBundleUnitQueryBuilder.php
+++ b/src/API/ContractServiceBundleUnits/ContractServiceBundleUnitQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractServiceBundleUnitQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractServiceBundleUnitQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractServiceBundles/ContractServiceBundleQueryBuilder.php
+++ b/src/API/ContractServiceBundles/ContractServiceBundleQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractServiceBundleQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractServiceBundleQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractServiceUnits/ContractServiceUnitQueryBuilder.php
+++ b/src/API/ContractServiceUnits/ContractServiceUnitQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractServiceUnitQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractServiceUnitQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractServices/ContractServiceQueryBuilder.php
+++ b/src/API/ContractServices/ContractServiceQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractServiceQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractServiceQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ContractTicketPurchases/ContractTicketPurchaseQueryBuilder.php
+++ b/src/API/ContractTicketPurchases/ContractTicketPurchaseQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractTicketPurchaseQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractTicketPurchaseQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Contracts/ContractQueryBuilder.php
+++ b/src/API/Contracts/ContractQueryBuilder.php
@@ -151,7 +151,7 @@ class ContractQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ContractQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Countries/CountryQueryBuilder.php
+++ b/src/API/Countries/CountryQueryBuilder.php
@@ -151,7 +151,7 @@ class CountryQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class CountryQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Currencies/CurrencyQueryBuilder.php
+++ b/src/API/Currencies/CurrencyQueryBuilder.php
@@ -151,7 +151,7 @@ class CurrencyQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class CurrencyQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/DeletedTaskActivityLogs/DeletedTaskActivityLogQueryBuilder.php
+++ b/src/API/DeletedTaskActivityLogs/DeletedTaskActivityLogQueryBuilder.php
@@ -151,7 +151,7 @@ class DeletedTaskActivityLogQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class DeletedTaskActivityLogQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/DeletedTicketActivityLogs/DeletedTicketActivityLogQueryBuilder.php
+++ b/src/API/DeletedTicketActivityLogs/DeletedTicketActivityLogQueryBuilder.php
@@ -151,7 +151,7 @@ class DeletedTicketActivityLogQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class DeletedTicketActivityLogQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/DeletedTicketLogs/DeletedTicketLogQueryBuilder.php
+++ b/src/API/DeletedTicketLogs/DeletedTicketLogQueryBuilder.php
@@ -151,7 +151,7 @@ class DeletedTicketLogQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class DeletedTicketLogQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Departments/DepartmentQueryBuilder.php
+++ b/src/API/Departments/DepartmentQueryBuilder.php
@@ -151,7 +151,7 @@ class DepartmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class DepartmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/DocumentAttachments/DocumentAttachmentQueryBuilder.php
+++ b/src/API/DocumentAttachments/DocumentAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class DocumentAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class DocumentAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/DocumentCategories/DocumentCategoryQueryBuilder.php
+++ b/src/API/DocumentCategories/DocumentCategoryQueryBuilder.php
@@ -151,7 +151,7 @@ class DocumentCategoryQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class DocumentCategoryQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/DocumentChecklistItems/DocumentChecklistItemQueryBuilder.php
+++ b/src/API/DocumentChecklistItems/DocumentChecklistItemQueryBuilder.php
@@ -151,7 +151,7 @@ class DocumentChecklistItemQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class DocumentChecklistItemQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/DocumentConfigurationItemAssociations/DocumentConfigurationItemAssociationQueryBuilder.php
+++ b/src/API/DocumentConfigurationItemAssociations/DocumentConfigurationItemAssociationQueryBuilder.php
@@ -151,7 +151,7 @@ class DocumentConfigurationItemAssociationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class DocumentConfigurationItemAssociationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/DocumentConfigurationItemCategoryAssociations/DocumentConfigurationItemCategoryAssociationQueryBuilder.php
+++ b/src/API/DocumentConfigurationItemCategoryAssociations/DocumentConfigurationItemCategoryAssociationQueryBuilder.php
@@ -151,7 +151,7 @@ class DocumentConfigurationItemCategoryAssociationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class DocumentConfigurationItemCategoryAssociationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/DocumentNotes/DocumentNoteQueryBuilder.php
+++ b/src/API/DocumentNotes/DocumentNoteQueryBuilder.php
@@ -151,7 +151,7 @@ class DocumentNoteQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class DocumentNoteQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/DocumentPlainTextContent/DocumentPlainTextContentQueryBuilder.php
+++ b/src/API/DocumentPlainTextContent/DocumentPlainTextContentQueryBuilder.php
@@ -151,7 +151,7 @@ class DocumentPlainTextContentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class DocumentPlainTextContentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/DocumentTagAssociations/DocumentTagAssociationQueryBuilder.php
+++ b/src/API/DocumentTagAssociations/DocumentTagAssociationQueryBuilder.php
@@ -151,7 +151,7 @@ class DocumentTagAssociationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class DocumentTagAssociationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/DocumentTicketAssociations/DocumentTicketAssociationQueryBuilder.php
+++ b/src/API/DocumentTicketAssociations/DocumentTicketAssociationQueryBuilder.php
@@ -151,7 +151,7 @@ class DocumentTicketAssociationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class DocumentTicketAssociationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/DocumentToArticleAssociations/DocumentToArticleAssociationQueryBuilder.php
+++ b/src/API/DocumentToArticleAssociations/DocumentToArticleAssociationQueryBuilder.php
@@ -151,7 +151,7 @@ class DocumentToArticleAssociationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class DocumentToArticleAssociationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/DocumentToDocumentAssociations/DocumentToDocumentAssociationQueryBuilder.php
+++ b/src/API/DocumentToDocumentAssociations/DocumentToDocumentAssociationQueryBuilder.php
@@ -151,7 +151,7 @@ class DocumentToDocumentAssociationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class DocumentToDocumentAssociationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Documents/DocumentQueryBuilder.php
+++ b/src/API/Documents/DocumentQueryBuilder.php
@@ -151,7 +151,7 @@ class DocumentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class DocumentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/DomainRegistrars/DomainRegistrarQueryBuilder.php
+++ b/src/API/DomainRegistrars/DomainRegistrarQueryBuilder.php
@@ -151,7 +151,7 @@ class DomainRegistrarQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class DomainRegistrarQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ExpenseItemAttachments/ExpenseItemAttachmentQueryBuilder.php
+++ b/src/API/ExpenseItemAttachments/ExpenseItemAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class ExpenseItemAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ExpenseItemAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ExpenseItems/ExpenseItemQueryBuilder.php
+++ b/src/API/ExpenseItems/ExpenseItemQueryBuilder.php
@@ -151,7 +151,7 @@ class ExpenseItemQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ExpenseItemQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ExpenseReportAttachments/ExpenseReportAttachmentQueryBuilder.php
+++ b/src/API/ExpenseReportAttachments/ExpenseReportAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class ExpenseReportAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ExpenseReportAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ExpenseReports/ExpenseReportQueryBuilder.php
+++ b/src/API/ExpenseReports/ExpenseReportQueryBuilder.php
@@ -151,7 +151,7 @@ class ExpenseReportQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ExpenseReportQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/HolidaySets/HolidaySetQueryBuilder.php
+++ b/src/API/HolidaySets/HolidaySetQueryBuilder.php
@@ -151,7 +151,7 @@ class HolidaySetQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class HolidaySetQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Holidays/HolidayQueryBuilder.php
+++ b/src/API/Holidays/HolidayQueryBuilder.php
@@ -151,7 +151,7 @@ class HolidayQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class HolidayQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/IntegrationVendorInsights/IntegrationVendorInsightQueryBuilder.php
+++ b/src/API/IntegrationVendorInsights/IntegrationVendorInsightQueryBuilder.php
@@ -151,7 +151,7 @@ class IntegrationVendorInsightQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class IntegrationVendorInsightQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/IntegrationVendorWidgets/IntegrationVendorWidgetQueryBuilder.php
+++ b/src/API/IntegrationVendorWidgets/IntegrationVendorWidgetQueryBuilder.php
@@ -151,7 +151,7 @@ class IntegrationVendorWidgetQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class IntegrationVendorWidgetQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/InternalLocationWithBusinessHours/InternalLocationWithBusinessHourQueryBuilder.php
+++ b/src/API/InternalLocationWithBusinessHours/InternalLocationWithBusinessHourQueryBuilder.php
@@ -151,7 +151,7 @@ class InternalLocationWithBusinessHourQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class InternalLocationWithBusinessHourQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/InternalLocations/InternalLocationQueryBuilder.php
+++ b/src/API/InternalLocations/InternalLocationQueryBuilder.php
@@ -151,7 +151,7 @@ class InternalLocationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class InternalLocationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/InventoryItemSerialNumbers/InventoryItemSerialNumberQueryBuilder.php
+++ b/src/API/InventoryItemSerialNumbers/InventoryItemSerialNumberQueryBuilder.php
@@ -151,7 +151,7 @@ class InventoryItemSerialNumberQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class InventoryItemSerialNumberQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/InventoryItems/InventoryItemQueryBuilder.php
+++ b/src/API/InventoryItems/InventoryItemQueryBuilder.php
@@ -151,7 +151,7 @@ class InventoryItemQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class InventoryItemQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/InventoryLocations/InventoryLocationQueryBuilder.php
+++ b/src/API/InventoryLocations/InventoryLocationQueryBuilder.php
@@ -151,7 +151,7 @@ class InventoryLocationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class InventoryLocationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/InventoryProducts/InventoryProductQueryBuilder.php
+++ b/src/API/InventoryProducts/InventoryProductQueryBuilder.php
@@ -151,7 +151,7 @@ class InventoryProductQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class InventoryProductQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/InventoryStockedItems/InventoryStockedItemQueryBuilder.php
+++ b/src/API/InventoryStockedItems/InventoryStockedItemQueryBuilder.php
@@ -151,7 +151,7 @@ class InventoryStockedItemQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class InventoryStockedItemQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/InventoryTransfers/InventoryTransferQueryBuilder.php
+++ b/src/API/InventoryTransfers/InventoryTransferQueryBuilder.php
@@ -151,7 +151,7 @@ class InventoryTransferQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class InventoryTransferQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/InvoiceTemplates/InvoiceTemplateQueryBuilder.php
+++ b/src/API/InvoiceTemplates/InvoiceTemplateQueryBuilder.php
@@ -151,7 +151,7 @@ class InvoiceTemplateQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class InvoiceTemplateQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Invoices/InvoiceQueryBuilder.php
+++ b/src/API/Invoices/InvoiceQueryBuilder.php
@@ -151,7 +151,7 @@ class InvoiceQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class InvoiceQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/KnowledgeBaseArticles/KnowledgeBaseArticleQueryBuilder.php
+++ b/src/API/KnowledgeBaseArticles/KnowledgeBaseArticleQueryBuilder.php
@@ -151,7 +151,7 @@ class KnowledgeBaseArticleQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class KnowledgeBaseArticleQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/KnowledgeBaseCategories/KnowledgeBaseCategoryQueryBuilder.php
+++ b/src/API/KnowledgeBaseCategories/KnowledgeBaseCategoryQueryBuilder.php
@@ -151,7 +151,7 @@ class KnowledgeBaseCategoryQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class KnowledgeBaseCategoryQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/NotificationHistory/NotificationHistoryQueryBuilder.php
+++ b/src/API/NotificationHistory/NotificationHistoryQueryBuilder.php
@@ -151,7 +151,7 @@ class NotificationHistoryQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class NotificationHistoryQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Opportunities/OpportunityQueryBuilder.php
+++ b/src/API/Opportunities/OpportunityQueryBuilder.php
@@ -151,7 +151,7 @@ class OpportunityQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class OpportunityQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/OpportunityAttachments/OpportunityAttachmentQueryBuilder.php
+++ b/src/API/OpportunityAttachments/OpportunityAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class OpportunityAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class OpportunityAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/OpportunityCategories/OpportunityCategoryQueryBuilder.php
+++ b/src/API/OpportunityCategories/OpportunityCategoryQueryBuilder.php
@@ -151,7 +151,7 @@ class OpportunityCategoryQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class OpportunityCategoryQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/OrganizationalLevel1s/OrganizationalLevel1QueryBuilder.php
+++ b/src/API/OrganizationalLevel1s/OrganizationalLevel1QueryBuilder.php
@@ -151,7 +151,7 @@ class OrganizationalLevel1QueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class OrganizationalLevel1QueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/OrganizationalLevel2s/OrganizationalLevel2QueryBuilder.php
+++ b/src/API/OrganizationalLevel2s/OrganizationalLevel2QueryBuilder.php
@@ -151,7 +151,7 @@ class OrganizationalLevel2QueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class OrganizationalLevel2QueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/OrganizationalLevelAssociations/OrganizationalLevelAssociationQueryBuilder.php
+++ b/src/API/OrganizationalLevelAssociations/OrganizationalLevelAssociationQueryBuilder.php
@@ -151,7 +151,7 @@ class OrganizationalLevelAssociationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class OrganizationalLevelAssociationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/OrganizationalResources/OrganizationalResourceQueryBuilder.php
+++ b/src/API/OrganizationalResources/OrganizationalResourceQueryBuilder.php
@@ -151,7 +151,7 @@ class OrganizationalResourceQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class OrganizationalResourceQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/PaymentTerms/PaymentTermQueryBuilder.php
+++ b/src/API/PaymentTerms/PaymentTermQueryBuilder.php
@@ -151,7 +151,7 @@ class PaymentTermQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class PaymentTermQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Phases/PhaseQueryBuilder.php
+++ b/src/API/Phases/PhaseQueryBuilder.php
@@ -151,7 +151,7 @@ class PhaseQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class PhaseQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/PriceListMaterialCodes/PriceListMaterialCodeQueryBuilder.php
+++ b/src/API/PriceListMaterialCodes/PriceListMaterialCodeQueryBuilder.php
@@ -151,7 +151,7 @@ class PriceListMaterialCodeQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class PriceListMaterialCodeQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/PriceListProductTiers/PriceListProductTierQueryBuilder.php
+++ b/src/API/PriceListProductTiers/PriceListProductTierQueryBuilder.php
@@ -151,7 +151,7 @@ class PriceListProductTierQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class PriceListProductTierQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/PriceListProducts/PriceListProductQueryBuilder.php
+++ b/src/API/PriceListProducts/PriceListProductQueryBuilder.php
@@ -151,7 +151,7 @@ class PriceListProductQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class PriceListProductQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/PriceListRoles/PriceListRoleQueryBuilder.php
+++ b/src/API/PriceListRoles/PriceListRoleQueryBuilder.php
@@ -151,7 +151,7 @@ class PriceListRoleQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class PriceListRoleQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/PriceListServiceBundles/PriceListServiceBundleQueryBuilder.php
+++ b/src/API/PriceListServiceBundles/PriceListServiceBundleQueryBuilder.php
@@ -151,7 +151,7 @@ class PriceListServiceBundleQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class PriceListServiceBundleQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/PriceListServices/PriceListServiceQueryBuilder.php
+++ b/src/API/PriceListServices/PriceListServiceQueryBuilder.php
@@ -151,7 +151,7 @@ class PriceListServiceQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class PriceListServiceQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/PriceListWorkTypeModifiers/PriceListWorkTypeModifierQueryBuilder.php
+++ b/src/API/PriceListWorkTypeModifiers/PriceListWorkTypeModifierQueryBuilder.php
@@ -151,7 +151,7 @@ class PriceListWorkTypeModifierQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class PriceListWorkTypeModifierQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ProductNotes/ProductNoteQueryBuilder.php
+++ b/src/API/ProductNotes/ProductNoteQueryBuilder.php
@@ -151,7 +151,7 @@ class ProductNoteQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ProductNoteQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ProductTiers/ProductTierQueryBuilder.php
+++ b/src/API/ProductTiers/ProductTierQueryBuilder.php
@@ -151,7 +151,7 @@ class ProductTierQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ProductTierQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ProductVendors/ProductVendorQueryBuilder.php
+++ b/src/API/ProductVendors/ProductVendorQueryBuilder.php
@@ -151,7 +151,7 @@ class ProductVendorQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ProductVendorQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Products/ProductQueryBuilder.php
+++ b/src/API/Products/ProductQueryBuilder.php
@@ -151,7 +151,7 @@ class ProductQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ProductQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ProjectAttachments/ProjectAttachmentQueryBuilder.php
+++ b/src/API/ProjectAttachments/ProjectAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class ProjectAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ProjectAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ProjectCharges/ProjectChargeQueryBuilder.php
+++ b/src/API/ProjectCharges/ProjectChargeQueryBuilder.php
@@ -151,7 +151,7 @@ class ProjectChargeQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ProjectChargeQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ProjectNoteAttachments/ProjectNoteAttachmentQueryBuilder.php
+++ b/src/API/ProjectNoteAttachments/ProjectNoteAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class ProjectNoteAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ProjectNoteAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ProjectNotes/ProjectNoteQueryBuilder.php
+++ b/src/API/ProjectNotes/ProjectNoteQueryBuilder.php
@@ -151,7 +151,7 @@ class ProjectNoteQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ProjectNoteQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Projects/ProjectQueryBuilder.php
+++ b/src/API/Projects/ProjectQueryBuilder.php
@@ -151,7 +151,7 @@ class ProjectQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ProjectQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/PurchaseApprovals/PurchaseApprovalQueryBuilder.php
+++ b/src/API/PurchaseApprovals/PurchaseApprovalQueryBuilder.php
@@ -151,7 +151,7 @@ class PurchaseApprovalQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class PurchaseApprovalQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/PurchaseOrderItemReceiving/PurchaseOrderItemReceivingQueryBuilder.php
+++ b/src/API/PurchaseOrderItemReceiving/PurchaseOrderItemReceivingQueryBuilder.php
@@ -151,7 +151,7 @@ class PurchaseOrderItemReceivingQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class PurchaseOrderItemReceivingQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/PurchaseOrderItems/PurchaseOrderItemQueryBuilder.php
+++ b/src/API/PurchaseOrderItems/PurchaseOrderItemQueryBuilder.php
@@ -151,7 +151,7 @@ class PurchaseOrderItemQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class PurchaseOrderItemQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/PurchaseOrders/PurchaseOrderQueryBuilder.php
+++ b/src/API/PurchaseOrders/PurchaseOrderQueryBuilder.php
@@ -151,7 +151,7 @@ class PurchaseOrderQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class PurchaseOrderQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/QuoteItems/QuoteItemQueryBuilder.php
+++ b/src/API/QuoteItems/QuoteItemQueryBuilder.php
@@ -151,7 +151,7 @@ class QuoteItemQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class QuoteItemQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/QuoteLocations/QuoteLocationQueryBuilder.php
+++ b/src/API/QuoteLocations/QuoteLocationQueryBuilder.php
@@ -151,7 +151,7 @@ class QuoteLocationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class QuoteLocationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/QuoteTemplates/QuoteTemplateQueryBuilder.php
+++ b/src/API/QuoteTemplates/QuoteTemplateQueryBuilder.php
@@ -151,7 +151,7 @@ class QuoteTemplateQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class QuoteTemplateQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Quotes/QuoteQueryBuilder.php
+++ b/src/API/Quotes/QuoteQueryBuilder.php
@@ -151,7 +151,7 @@ class QuoteQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class QuoteQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ResourceAttachments/ResourceAttachmentQueryBuilder.php
+++ b/src/API/ResourceAttachments/ResourceAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class ResourceAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ResourceAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ResourceDailyAvailabilities/ResourceDailyAvailabilityQueryBuilder.php
+++ b/src/API/ResourceDailyAvailabilities/ResourceDailyAvailabilityQueryBuilder.php
@@ -151,7 +151,7 @@ class ResourceDailyAvailabilityQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ResourceDailyAvailabilityQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ResourceRoleDepartments/ResourceRoleDepartmentQueryBuilder.php
+++ b/src/API/ResourceRoleDepartments/ResourceRoleDepartmentQueryBuilder.php
@@ -151,7 +151,7 @@ class ResourceRoleDepartmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ResourceRoleDepartmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ResourceRoleQueues/ResourceRoleQueueQueryBuilder.php
+++ b/src/API/ResourceRoleQueues/ResourceRoleQueueQueryBuilder.php
@@ -151,7 +151,7 @@ class ResourceRoleQueueQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ResourceRoleQueueQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ResourceRoles/ResourceRoleQueryBuilder.php
+++ b/src/API/ResourceRoles/ResourceRoleQueryBuilder.php
@@ -151,7 +151,7 @@ class ResourceRoleQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ResourceRoleQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ResourceServiceDeskRoles/ResourceServiceDeskRoleQueryBuilder.php
+++ b/src/API/ResourceServiceDeskRoles/ResourceServiceDeskRoleQueryBuilder.php
@@ -151,7 +151,7 @@ class ResourceServiceDeskRoleQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ResourceServiceDeskRoleQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ResourceSkills/ResourceSkillQueryBuilder.php
+++ b/src/API/ResourceSkills/ResourceSkillQueryBuilder.php
@@ -151,7 +151,7 @@ class ResourceSkillQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ResourceSkillQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Resources/ResourceEntity.php
+++ b/src/API/Resources/ResourceEntity.php
@@ -38,6 +38,7 @@ class ResourceEntity extends DataTransferObject
     public ?string $officeExtension;
     public ?string $officePhone;
     public int $payrollType;
+    public ?string $payrollIdentifier;
     public string $resourceType;
     public ?int $suffix;
     public ?float $surveyResourceRating;

--- a/src/API/Resources/ResourceQueryBuilder.php
+++ b/src/API/Resources/ResourceQueryBuilder.php
@@ -151,7 +151,7 @@ class ResourceQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ResourceQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Roles/RoleQueryBuilder.php
+++ b/src/API/Roles/RoleQueryBuilder.php
@@ -151,7 +151,7 @@ class RoleQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class RoleQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/SalesOrderAttachments/SalesOrderAttachmentQueryBuilder.php
+++ b/src/API/SalesOrderAttachments/SalesOrderAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class SalesOrderAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class SalesOrderAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/SalesOrders/SalesOrderQueryBuilder.php
+++ b/src/API/SalesOrders/SalesOrderQueryBuilder.php
@@ -151,7 +151,7 @@ class SalesOrderQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class SalesOrderQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ServiceBundleServices/ServiceBundleServiceQueryBuilder.php
+++ b/src/API/ServiceBundleServices/ServiceBundleServiceQueryBuilder.php
@@ -151,7 +151,7 @@ class ServiceBundleServiceQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ServiceBundleServiceQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ServiceBundles/ServiceBundleQueryBuilder.php
+++ b/src/API/ServiceBundles/ServiceBundleQueryBuilder.php
@@ -151,7 +151,7 @@ class ServiceBundleQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ServiceBundleQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ServiceCallTaskResources/ServiceCallTaskResourceQueryBuilder.php
+++ b/src/API/ServiceCallTaskResources/ServiceCallTaskResourceQueryBuilder.php
@@ -151,7 +151,7 @@ class ServiceCallTaskResourceQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ServiceCallTaskResourceQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ServiceCallTasks/ServiceCallTaskQueryBuilder.php
+++ b/src/API/ServiceCallTasks/ServiceCallTaskQueryBuilder.php
@@ -151,7 +151,7 @@ class ServiceCallTaskQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ServiceCallTaskQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ServiceCallTicketResources/ServiceCallTicketResourceQueryBuilder.php
+++ b/src/API/ServiceCallTicketResources/ServiceCallTicketResourceQueryBuilder.php
@@ -151,7 +151,7 @@ class ServiceCallTicketResourceQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ServiceCallTicketResourceQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ServiceCallTickets/ServiceCallTicketQueryBuilder.php
+++ b/src/API/ServiceCallTickets/ServiceCallTicketQueryBuilder.php
@@ -151,7 +151,7 @@ class ServiceCallTicketQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ServiceCallTicketQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ServiceCalls/ServiceCallQueryBuilder.php
+++ b/src/API/ServiceCalls/ServiceCallQueryBuilder.php
@@ -151,7 +151,7 @@ class ServiceCallQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ServiceCallQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ServiceLevelAgreementResults/ServiceLevelAgreementResultQueryBuilder.php
+++ b/src/API/ServiceLevelAgreementResults/ServiceLevelAgreementResultQueryBuilder.php
@@ -151,7 +151,7 @@ class ServiceLevelAgreementResultQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ServiceLevelAgreementResultQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Services/ServiceQueryBuilder.php
+++ b/src/API/Services/ServiceQueryBuilder.php
@@ -151,7 +151,7 @@ class ServiceQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ServiceQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/ShippingTypes/ShippingTypeQueryBuilder.php
+++ b/src/API/ShippingTypes/ShippingTypeQueryBuilder.php
@@ -151,7 +151,7 @@ class ShippingTypeQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class ShippingTypeQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Skills/SkillQueryBuilder.php
+++ b/src/API/Skills/SkillQueryBuilder.php
@@ -151,7 +151,7 @@ class SkillQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class SkillQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/SubscriptionPeriods/SubscriptionPeriodQueryBuilder.php
+++ b/src/API/SubscriptionPeriods/SubscriptionPeriodQueryBuilder.php
@@ -151,7 +151,7 @@ class SubscriptionPeriodQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class SubscriptionPeriodQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Subscriptions/SubscriptionQueryBuilder.php
+++ b/src/API/Subscriptions/SubscriptionQueryBuilder.php
@@ -151,7 +151,7 @@ class SubscriptionQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class SubscriptionQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/SurveyResults/SurveyResultQueryBuilder.php
+++ b/src/API/SurveyResults/SurveyResultQueryBuilder.php
@@ -151,7 +151,7 @@ class SurveyResultQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class SurveyResultQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Surveys/SurveyQueryBuilder.php
+++ b/src/API/Surveys/SurveyQueryBuilder.php
@@ -151,7 +151,7 @@ class SurveyQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class SurveyQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TagAliases/TagAliasQueryBuilder.php
+++ b/src/API/TagAliases/TagAliasQueryBuilder.php
@@ -151,7 +151,7 @@ class TagAliasQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TagAliasQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TagGroups/TagGroupQueryBuilder.php
+++ b/src/API/TagGroups/TagGroupQueryBuilder.php
@@ -151,7 +151,7 @@ class TagGroupQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TagGroupQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Tags/TagQueryBuilder.php
+++ b/src/API/Tags/TagQueryBuilder.php
@@ -151,7 +151,7 @@ class TagQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TagQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TaskAttachments/TaskAttachmentQueryBuilder.php
+++ b/src/API/TaskAttachments/TaskAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class TaskAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TaskAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TaskNoteAttachments/TaskNoteAttachmentQueryBuilder.php
+++ b/src/API/TaskNoteAttachments/TaskNoteAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class TaskNoteAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TaskNoteAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TaskNotes/TaskNoteQueryBuilder.php
+++ b/src/API/TaskNotes/TaskNoteQueryBuilder.php
@@ -151,7 +151,7 @@ class TaskNoteQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TaskNoteQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TaskPredecessors/TaskPredecessorQueryBuilder.php
+++ b/src/API/TaskPredecessors/TaskPredecessorQueryBuilder.php
@@ -151,7 +151,7 @@ class TaskPredecessorQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TaskPredecessorQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TaskSecondaryResources/TaskSecondaryResourceQueryBuilder.php
+++ b/src/API/TaskSecondaryResources/TaskSecondaryResourceQueryBuilder.php
@@ -151,7 +151,7 @@ class TaskSecondaryResourceQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TaskSecondaryResourceQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Tasks/TaskQueryBuilder.php
+++ b/src/API/Tasks/TaskQueryBuilder.php
@@ -151,7 +151,7 @@ class TaskQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TaskQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TaxCategories/TaxCategoryQueryBuilder.php
+++ b/src/API/TaxCategories/TaxCategoryQueryBuilder.php
@@ -151,7 +151,7 @@ class TaxCategoryQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TaxCategoryQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TaxRegions/TaxRegionQueryBuilder.php
+++ b/src/API/TaxRegions/TaxRegionQueryBuilder.php
@@ -151,7 +151,7 @@ class TaxRegionQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TaxRegionQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Taxes/TaxQueryBuilder.php
+++ b/src/API/Taxes/TaxQueryBuilder.php
@@ -151,7 +151,7 @@ class TaxQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TaxQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketAdditionalConfigurationItems/TicketAdditionalConfigurationItemQueryBuilder.php
+++ b/src/API/TicketAdditionalConfigurationItems/TicketAdditionalConfigurationItemQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketAdditionalConfigurationItemQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketAdditionalConfigurationItemQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketAdditionalContacts/TicketAdditionalContactQueryBuilder.php
+++ b/src/API/TicketAdditionalContacts/TicketAdditionalContactQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketAdditionalContactQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketAdditionalContactQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketAttachments/TicketAttachmentEntity.php
+++ b/src/API/TicketAttachments/TicketAttachmentEntity.php
@@ -59,6 +59,11 @@ class TicketAttachmentEntity extends DataTransferObject
     {
         $responseArray = json_decode($response->getBody(), true);
 
+        //findByID method returns $responseArray["items"], but there should always only be 1 item returned from the API by ID. 
+        if(isset($responseArray["items"]) && is_array($responseArray["items"]) && count($responseArray["items"]) == 1){
+            return new self($responseArray["items"][0]);
+        }
+
         if (isset($responseArray['item']) === false) {
             throw new \Exception('Missing item key in response.');
         }

--- a/src/API/TicketAttachments/TicketAttachmentQueryBuilder.php
+++ b/src/API/TicketAttachments/TicketAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketCategories/TicketCategoryQueryBuilder.php
+++ b/src/API/TicketCategories/TicketCategoryQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketCategoryQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketCategoryQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketCategoryFieldDefaults/TicketCategoryFieldDefaultQueryBuilder.php
+++ b/src/API/TicketCategoryFieldDefaults/TicketCategoryFieldDefaultQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketCategoryFieldDefaultQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketCategoryFieldDefaultQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketChangeRequestApprovals/TicketChangeRequestApprovalQueryBuilder.php
+++ b/src/API/TicketChangeRequestApprovals/TicketChangeRequestApprovalQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketChangeRequestApprovalQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketChangeRequestApprovalQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketCharges/TicketChargeQueryBuilder.php
+++ b/src/API/TicketCharges/TicketChargeQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketChargeQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketChargeQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketChecklistItems/TicketChecklistItemQueryBuilder.php
+++ b/src/API/TicketChecklistItems/TicketChecklistItemQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketChecklistItemQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketChecklistItemQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketHistory/TicketHistoryQueryBuilder.php
+++ b/src/API/TicketHistory/TicketHistoryQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketHistoryQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketHistoryQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketNoteAttachments/TicketNoteAttachmentQueryBuilder.php
+++ b/src/API/TicketNoteAttachments/TicketNoteAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketNoteAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketNoteAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketNoteWebhookExcludedResources/TicketNoteWebhookExcludedResourceQueryBuilder.php
+++ b/src/API/TicketNoteWebhookExcludedResources/TicketNoteWebhookExcludedResourceQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketNoteWebhookExcludedResourceQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketNoteWebhookExcludedResourceQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketNoteWebhookFields/TicketNoteWebhookFieldQueryBuilder.php
+++ b/src/API/TicketNoteWebhookFields/TicketNoteWebhookFieldQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketNoteWebhookFieldQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketNoteWebhookFieldQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketNoteWebhooks/TicketNoteWebhookQueryBuilder.php
+++ b/src/API/TicketNoteWebhooks/TicketNoteWebhookQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketNoteWebhookQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketNoteWebhookQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketNotes/TicketNoteQueryBuilder.php
+++ b/src/API/TicketNotes/TicketNoteQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketNoteQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketNoteQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketRmaCredits/TicketRmaCreditQueryBuilder.php
+++ b/src/API/TicketRmaCredits/TicketRmaCreditQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketRmaCreditQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketRmaCreditQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketSecondaryResources/TicketSecondaryResourceQueryBuilder.php
+++ b/src/API/TicketSecondaryResources/TicketSecondaryResourceQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketSecondaryResourceQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketSecondaryResourceQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketTagAssociations/TicketTagAssociationQueryBuilder.php
+++ b/src/API/TicketTagAssociations/TicketTagAssociationQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketTagAssociationQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketTagAssociationQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketWebhookExcludedResources/TicketWebhookExcludedResourceQueryBuilder.php
+++ b/src/API/TicketWebhookExcludedResources/TicketWebhookExcludedResourceQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketWebhookExcludedResourceQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketWebhookExcludedResourceQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketWebhookFields/TicketWebhookFieldQueryBuilder.php
+++ b/src/API/TicketWebhookFields/TicketWebhookFieldQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketWebhookFieldQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketWebhookFieldQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketWebhookUdfFields/TicketWebhookUdfFieldQueryBuilder.php
+++ b/src/API/TicketWebhookUdfFields/TicketWebhookUdfFieldQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketWebhookUdfFieldQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketWebhookUdfFieldQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TicketWebhooks/TicketWebhookQueryBuilder.php
+++ b/src/API/TicketWebhooks/TicketWebhookQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketWebhookQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketWebhookQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/Tickets/TicketQueryBuilder.php
+++ b/src/API/Tickets/TicketQueryBuilder.php
@@ -151,7 +151,7 @@ class TicketQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TicketQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TimeEntries/TimeEntryQueryBuilder.php
+++ b/src/API/TimeEntries/TimeEntryQueryBuilder.php
@@ -151,7 +151,7 @@ class TimeEntryQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TimeEntryQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TimeEntryAttachments/TimeEntryAttachmentQueryBuilder.php
+++ b/src/API/TimeEntryAttachments/TimeEntryAttachmentQueryBuilder.php
@@ -151,7 +151,7 @@ class TimeEntryAttachmentQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TimeEntryAttachmentQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/TimeOffRequests/TimeOffRequestQueryBuilder.php
+++ b/src/API/TimeOffRequests/TimeOffRequestQueryBuilder.php
@@ -151,7 +151,7 @@ class TimeOffRequestQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class TimeOffRequestQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/UserDefinedFieldDefinitions/UserDefinedFieldDefinitionQueryBuilder.php
+++ b/src/API/UserDefinedFieldDefinitions/UserDefinedFieldDefinitionQueryBuilder.php
@@ -151,7 +151,7 @@ class UserDefinedFieldDefinitionQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class UserDefinedFieldDefinitionQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/UserDefinedFieldListItems/UserDefinedFieldListItemQueryBuilder.php
+++ b/src/API/UserDefinedFieldListItems/UserDefinedFieldListItemQueryBuilder.php
@@ -151,7 +151,7 @@ class UserDefinedFieldListItemQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class UserDefinedFieldListItemQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/WebhookEventErrorLogs/WebhookEventErrorLogQueryBuilder.php
+++ b/src/API/WebhookEventErrorLogs/WebhookEventErrorLogQueryBuilder.php
@@ -151,7 +151,7 @@ class WebhookEventErrorLogQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class WebhookEventErrorLogQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);

--- a/src/API/WorkTypeModifiers/WorkTypeModifierQueryBuilder.php
+++ b/src/API/WorkTypeModifiers/WorkTypeModifierQueryBuilder.php
@@ -151,7 +151,7 @@ class WorkTypeModifierQueryBuilder
      */
     public function where(
         $field,
-        $operator = null,
+        $operator = '',
         $value = null,
         $udf = false,
         $conjuction = 'AND'
@@ -180,7 +180,7 @@ class WorkTypeModifierQueryBuilder
         // Second scenario, everything is set and legit.
         if (
             isset($field) &&
-            $operator !== null &&
+            $operator !== '' &&
             $value !== null
         ) {
             $this->validateOperator($operator);


### PR DESCRIPTION
https://www.php.net/manual/en/migration81.deprecated.php

Passing null to non-nullable parameters of built-in functions[ ¶](https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.null-not-nullable-internal)
Scalar types for built-in functions are nullable by default. This behaviour is deprecated to align with the behaviour of user-defined functions, where scalar types need to be marked as nullable explicitly.