### PR TITLE
Fixed issue causing failures when assigning values from API to php entity classes.

### DIFF
--- a/src/API/CompanyCategories/CompanyCategoryEntity.php
+++ b/src/API/CompanyCategories/CompanyCategoryEntity.php
@@ -10,7 +10,7 @@ use Spatie\DataTransferObject\DataTransferObject;
  */
 class CompanyCategoryEntity extends DataTransferObject
 {
-    public ?int $displayColorRgb;
+    public int $displayColorRGB;
     public $id;
     public bool $isActive;
     public ?bool $isApiOnly;

--- a/src/API/CompanyCategories/CompanyCategoryEntity.php
+++ b/src/API/CompanyCategories/CompanyCategoryEntity.php
@@ -10,7 +10,7 @@ use Spatie\DataTransferObject\DataTransferObject;
  */
 class CompanyCategoryEntity extends DataTransferObject
 {
-    public int $displayColorRgb;
+    public ?int $displayColorRgb;
     public $id;
     public bool $isActive;
     public ?bool $isApiOnly;

--- a/src/API/ConfigurationItemCategories/ConfigurationItemCategoryEntity.php
+++ b/src/API/ConfigurationItemCategories/ConfigurationItemCategoryEntity.php
@@ -10,7 +10,7 @@ use Spatie\DataTransferObject\DataTransferObject;
  */
 class ConfigurationItemCategoryEntity extends DataTransferObject
 {
-    public int $displayColorRgb;
+    public int $displayColorRGB;
     public $id;
     public bool $isActive;
     public ?bool $isClientPortalDefault;

--- a/src/API/KnowledgeBaseCategories/KnowledgeBaseCategoryEntity.php
+++ b/src/API/KnowledgeBaseCategories/KnowledgeBaseCategoryEntity.php
@@ -13,7 +13,7 @@ class KnowledgeBaseCategoryEntity extends DataTransferObject
     public ?string $description;
     public $id;
     public string $name;
-    public int $parentCategoryID;
+    public ?int $parentCategoryID;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;
 

--- a/src/API/OpportunityCategories/OpportunityCategoryEntity.php
+++ b/src/API/OpportunityCategories/OpportunityCategoryEntity.php
@@ -10,7 +10,7 @@ use Spatie\DataTransferObject\DataTransferObject;
  */
 class OpportunityCategoryEntity extends DataTransferObject
 {
-    public int $displayColorRgb;
+    public int $displayColorRGB;
     public $id;
     public bool $isActive;
     public ?bool $isGlobalDefault;

--- a/src/API/PurchaseApprovals/PurchaseApprovalEntity.php
+++ b/src/API/PurchaseApprovals/PurchaseApprovalEntity.php
@@ -12,7 +12,7 @@ class PurchaseApprovalEntity extends DataTransferObject
 {
     public ?string $costType;
     public $id;
-    public bool $isApproved;
+    public ?bool $isApproved;
     public ?string $rejectNote;
     /** @var \Anteris\Autotask\Support\UserDefinedFields\UserDefinedFieldEntity[]|null */
     public ?array $userDefinedFields;

--- a/src/API/SalesOrders/SalesOrderEntity.php
+++ b/src/API/SalesOrders/SalesOrderEntity.php
@@ -20,7 +20,7 @@ class SalesOrderEntity extends DataTransferObject
     public ?string $billToPostalCode;
     public ?string $billToState;
     public int $companyID;
-    public int $contactID;
+    public ?int $contactID;
     public int $id;
     public ?int $impersonatorCreatorResourceID;
     public int $opportunityID;

--- a/src/API/TicketCategories/TicketCategoryEntity.php
+++ b/src/API/TicketCategories/TicketCategoryEntity.php
@@ -10,7 +10,7 @@ use Spatie\DataTransferObject\DataTransferObject;
  */
 class TicketCategoryEntity extends DataTransferObject
 {
-    public int $displayColorRgb;
+    public int $displayColorRGB;
     public $id;
     public bool $isActive;
     public ?bool $isApiOnly;


### PR DESCRIPTION
All instances of "Rgb" need to be changed to "RGB" so that they match what ends up in the data transfer class. (The property names are case sensitive).

Initially I thought it was caused by the property not being null-able so I made the int null-able, but it turns out that it is a required field, just the original variable names in the class definitions followed camel case rather than the casing used by the folks over at Datto who decided to be inconsistent...(who would've thought...)

I then checked to see if there was any other classes with issue and fixed those as well. 😄

Example of an error I recieved that this pull request resolves:
```
PHP Fatal error:  Uncaught TypeError: Cannot assign null to property Anteris\Autotask\API\CompanyCategories\CompanyCategoryEntity::$displayColorRgb of type int in /home/cbarone/autotask-migration/vendor/spatie/data-transfer-object/src/Reflection/DataTransferObjectProperty.php:48
Stack trace:
#0 /home/cbarone/autotask-migration/vendor/spatie/data-transfer-object/src/Reflection/DataTransferObjectProperty.php(48): ReflectionProperty->setValue()
#1 /home/cbarone/autotask-migration/vendor/spatie/data-transfer-object/src/DataTransferObject.php(29): Spatie\DataTransferObject\Reflection\DataTransferObjectProperty->setValue()
#2 /home/cbarone/autotask-migration/vendor/anteris-dev/autotask-client/src/API/CompanyCategories/CompanyCategoryEntity.php(31): Spatie\DataTransferObject\DataTransferObject->__construct()
#3 /home/cbarone/autotask-migration/vendor/spatie/data-transfer-object/src/DataTransferObject.php(44): Anteris\Autotask\API\CompanyCategories\CompanyCategoryEntity->__construct()
#4 [internal function]: Spatie\DataTransferObject\DataTransferObject::Spatie\DataTransferObject\{closure}()
#5 /home/cbarone/autotask-migration/vendor/spatie/data-transfer-object/src/DataTransferObject.php(44): array_map()
#6 /home/cbarone/autotask-migration/vendor/anteris-dev/autotask-client/src/API/CompanyCategories/CompanyCategoryCollection.php(46): Spatie\DataTransferObject\DataTransferObject::arrayOf()
#7 /home/cbarone/autotask-migration/vendor/anteris-dev/autotask-client/src/API/CompanyCategories/CompanyCategoryQueryBuilder.php(101): Anteris\Autotask\API\CompanyCategories\CompanyCategoryCollection::fromResponse()
#8 /home/cbarone/autotask-migration/run.php(257): Anteris\Autotask\API\CompanyCategories\CompanyCategoryQueryBuilder->get()
#9 /home/cbarone/autotask-migration/run.php(407): exportEntity()
#10 {main}
  thrown in /home/cbarone/autotask-migration/vendor/spatie/data-transfer-object/src/Reflection/DataTransferObjectProperty.php on line 48
```